### PR TITLE
Make write timeout configurable

### DIFF
--- a/panics.go
+++ b/panics.go
@@ -451,7 +451,6 @@ func handlePanic(e *Error, timeout time.Duration) {
 	}
 
 	// If logging is enabled, do not indefinitely block on it.
-	done := make(chan struct{})
 	writeErrorFn := func(wr *writer, done chan<- struct{}) {
 		defer func() {
 			if done != nil {
@@ -463,6 +462,7 @@ func handlePanic(e *Error, timeout time.Duration) {
 	}
 
 	if timeout > 0 {
+		done := make(chan struct{})
 		go writeErrorFn(wr, done)
 		to := time.NewTimer(timeout)
 		select {

--- a/panics.go
+++ b/panics.go
@@ -25,7 +25,7 @@ import (
 // that is cancelled on any panic. If propagated then this will cancel
 // any inflight requests/work helping to prepare for exit.
 
-// DefaultWriteTimeout is the default value of writeTimeout.
+// DefaultWriteTimeout is the default value of [WriteTimeout].
 const DefaultWriteTimeout = 500 * time.Millisecond
 
 var (
@@ -471,9 +471,9 @@ func handlePanic(e *Error, timeout time.Duration) {
 		case <-done:
 			to.Stop()
 		}
-	} else {
-		writeErrorFn(wr, nil)
+		return
 	}
+	writeErrorFn(wr, nil)
 }
 
 // Capture calls function fn directly, not in a goroutine, safely recovers

--- a/panics_test.go
+++ b/panics_test.go
@@ -921,11 +921,11 @@ func TestWriteTimeout(t *testing.T) {
 	testSetup(t)
 
 	if writeTimeout.Load() != int64(100*time.Millisecond) {
-		t.Errorf("Expected default to be set to 100ms, but got %d.", time.Duration(writeTimeout.Load()))
+		t.Errorf("Expected default writeTimeout to be set to 100ms, but got %d.", time.Duration(writeTimeout.Load()))
 	}
 	WriteTimeout(90 * time.Millisecond)
 	if writeTimeout.Load() != int64(90*time.Millisecond) {
-		t.Errorf("Expected default to be set to 90ms, but got %d.", time.Duration(writeTimeout.Load()))
+		t.Errorf("Expected writeTimeout to be set to 90ms, but got %d.", time.Duration(writeTimeout.Load()))
 	}
 }
 

--- a/panics_test.go
+++ b/panics_test.go
@@ -920,7 +920,7 @@ func TestSetOutputNilWriter(t *testing.T) {
 func TestWriteTimeout(t *testing.T) {
 	testSetup(t)
 
-	if writeTimeout.Load() != int64(100*time.Millisecond) {
+	if writeTimeout.Load() != int64(500*time.Millisecond) {
 		t.Errorf("Expected default writeTimeout to be set to 100ms, but got %d.", time.Duration(writeTimeout.Load()))
 	}
 	WriteTimeout(90 * time.Millisecond)

--- a/panics_test.go
+++ b/panics_test.go
@@ -917,6 +917,18 @@ func TestSetOutputNilWriter(t *testing.T) {
 	fmt.Fprintln(output.Load(), "DO NOT PANIC")
 }
 
+func TestWriteTimeout(t *testing.T) {
+	testSetup(t)
+
+	if writeTimeout.Load() != int64(100*time.Millisecond) {
+		t.Errorf("Expected default to be set to 100ms, but got %d.", time.Duration(writeTimeout.Load()))
+	}
+	WriteTimeout(90 * time.Millisecond)
+	if writeTimeout.Load() != int64(90*time.Millisecond) {
+		t.Errorf("Expected default to be set to 90ms, but got %d.", time.Duration(writeTimeout.Load()))
+	}
+}
+
 func TestSetOutputPanickingWriter(t *testing.T) {
 	testSetup(t)
 


### PR DESCRIPTION
Make the write timeout (defined as "the maximum amount of time to wait for a panic to be written to output before handling the panic") configurable. 